### PR TITLE
Stop swallowing errors inside async's callback

### DIFF
--- a/lib/spreadsheet.js
+++ b/lib/spreadsheet.js
@@ -1,4 +1,3 @@
-var async = require('async')
 var q = require('q')
 var _ = require('lodash')
 var google = require('googleapis');
@@ -52,35 +51,28 @@ function Spreadsheet () {
 
 Spreadsheet.prototype.update = function () {
   var self = this
-  var deferred = q.defer()
 
-  async.parallel({
-    list: function (callback) {
-      api.getList()
-        .then(function (res) {
-          callback(null, res)
+  return q.all([
+    //list
+    api.getList(),
+    //lastRow
+    self.readSheet(self.SHEET_NAME)
+      .then(function (result) {
+        var lastRowIdx = _.size(result)
+        var lastRow = _.findLast(result, function(n) {
+          return n;
         })
-        .catch(callback)
-    },
-    lastRow: function (callback) {
-      self.readSheet(self.SHEET_NAME)
-        .then(function (result) {
-          var lastRowIdx = _.size(result)
-          var lastRow = _.findLast(result, function(n) {
-            return n;
-          })
 
-          callback(null, {
-            index: lastRowIdx,
-            value: lastRow,
-          })
-        })
-        .catch(callback)
+        return {
+          index: lastRowIdx,
+          value: lastRow,
+        }
+      }),
+  ]).then(function(resultsArray) {
+    var results = {
+        list: resultsArray[0],
+        lastRow: resultsArray[1]
     }
-  },
-  function(err, results) {
-    if (err) return deferred.reject(err)
-
     var updateObj = {}
     var newItems = _.filter(results.list, function(obj) {
       var feedbackText = obj.text || '';
@@ -113,12 +105,8 @@ Spreadsheet.prototype.update = function () {
       ]
     })
 
-    self.updateSheet(self.SHEET_NAME, updateObj)
-      .then(deferred.resolve)
-      .catch(deferred.reject)
+    return self.updateSheet(self.SHEET_NAME, updateObj)
   })
-
-  return deferred.promise
 }
 
 Spreadsheet.prototype.updateSheet = function (sheet, cells) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "async": "1.3.0",
     "edit-google-spreadsheet": "0.2.19",
     "express": "4.13.1",
     "google-spreadsheet": "^2.0.3",


### PR DESCRIPTION
async.parallel will silently swallow errors if used with promises in this way.
Instead, we can use Q.all(), which takes an array instead of an
object as it's first argument.

Bonus: we can remove async from this project's dependencies.